### PR TITLE
Add 'amount' to TransferMemo event.

### DIFF
--- a/substrate/frame/balances/src/impls.rs
+++ b/substrate/frame/balances/src/impls.rs
@@ -18,7 +18,7 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 		memo: Option<T::Memo>,
 	) -> DispatchResult {
 		<Self as Currency<T::AccountId>>::transfer(source, dest, amount, er).map(|_| amount)?;
-		Self::deposit_event(Event::TransferMemo { from: source.clone(), to: dest.clone(), memo });
+		Self::deposit_event(Event::TransferMemo { from: source.clone(), to: dest.clone(), amount, memo });
 		Ok(())
 	}
 }

--- a/substrate/frame/balances/src/lib.rs
+++ b/substrate/frame/balances/src/lib.rs
@@ -519,7 +519,7 @@ pub mod pallet {
 		/// Some amount was removed from the account (e.g. for misbehavior).
 		Slashed { who: T::AccountId, amount: T::Balance },
 		/// Transfer with memo succeeded.
-		TransferMemo { from: T::AccountId, to: T::AccountId, memo: Option<T::Memo> },
+		TransferMemo { from: T::AccountId, to: T::AccountId, amount: T::Balance, memo: Option<T::Memo> },
 	}
 
 	#[pallet::error]


### PR DESCRIPTION
Make sure the `TransferMemo` event has all the information from the `Transfer` event.